### PR TITLE
公式情報取得時にidStringをアップデートするように

### DIFF
--- a/OngekiMuseumApi/OngekiMuseumApi/Models/OfficialMusic.cs
+++ b/OngekiMuseumApi/OngekiMuseumApi/Models/OfficialMusic.cs
@@ -57,7 +57,7 @@ public class OfficialMusic : ITimestamp
     /// 楽曲ID
     /// </summary>
     [MaxLength(6)]
-    public string? IdString { get; init; }
+    public string? IdString { get; set; }
 
     /// <summary>
     /// チャプターID

--- a/OngekiMuseumApi/OngekiMuseumApi/Services/OfficialMusicService.cs
+++ b/OngekiMuseumApi/OngekiMuseumApi/Services/OfficialMusicService.cs
@@ -213,6 +213,11 @@ public class OfficialMusicService(
                             updateLog += $"\nArtist: {existingMusic.Artist} → {musicJson.artist}";
                             existingMusic.Artist = NullIfEmpty(musicJson.artist);
                         }
+                        if (!string.Equals(existingMusic.IdString, NullIfEmpty(musicJson.id)))
+                        {
+                            updateLog += $"\nIdString: {existingMusic.IdString} → {musicJson.id}";
+                            existingMusic.IdString = NullIfEmpty(musicJson.id);
+                        }
                         if (!string.Equals(existingMusic.ChapId, NullIfEmpty(musicJson.chap_id)))
                         {
                             updateLog += $"\nChapId: {existingMusic.ChapId} → {musicJson.chap_id}";


### PR DESCRIPTION
これが変わることもある（かわらないで＞＜）

This pull request includes changes to the `OngekiMuseumApi` project to improve the handling and logging of the `IdString` property in the `OfficialMusic` model and its associated service.

Changes to `OfficialMusic` model and service:

* [`OngekiMuseumApi/OngekiMuseumApi/Models/OfficialMusic.cs`](diffhunk://#diff-9cf9bca6ea09916d69e95bbf95670f1b32b19fdbed7515234c56cfce0314ae08L60-R60): Changed the `IdString` property from `init` to `set` to allow for updates.
* [`OngekiMuseumApi/OngekiMuseumApi/Services/OfficialMusicService.cs`](diffhunk://#diff-8e22e9ad9fb0fb131690210c055d3d955c6bdb4cd1a80d1e03527bba27ea56d2R216-R220): Added logging and updating logic for the `IdString` property in the `FetchAndSaveOfficialMusicAsync` method.